### PR TITLE
IGB AVB support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -102,7 +102,7 @@ config MSE_PACKETIZER_CVF_MJPEG
 config MSE_ADAPTER_EAVB
 	tristate "MSE EAVB Adapter"
 	depends on MSE_CORE
-	depends on RAVB_STREAMING
+	depends on RAVB_STREAMING || IGB_STREAMING
 	default m
 	---help---
 	  Renesas Ethernet AVB software

--- a/mse_adapter_eavb.c
+++ b/mse_adapter_eavb.c
@@ -423,6 +423,7 @@ static int mse_adapter_eavb_send_prepare(int index,
 		(eavb->entry + i)->seq_no = i;
 		(eavb->entry + i)->vec[0].base = packets[i].paddr;
 		(eavb->entry + i)->vec[0].len = packets[i].len;
+		(eavb->entry + i)->vec[0].vaddr = packets[i].vaddr;
 	}
 
 	eavb->entried = 0;
@@ -586,6 +587,7 @@ static int mse_adapter_eavb_receive_prepare(int index,
 		(eavb->entry + i)->seq_no = i;
 		(eavb->entry + i)->vec[0].base = packets[i].paddr;
 		(eavb->entry + i)->vec[0].len = packets[i].len;
+		(eavb->entry + i)->vec[0].vaddr = packets[i].vaddr;
 	}
 
 	/* entry queue */


### PR DESCRIPTION
This pull request is depending on

- https://github.com/twischer/linux/pull/1
- https://github.com/renesas-rcar/avb-streaming/pull/2

It introduces the required modification to support Intel Gigabit Network cards by this avb-mse implementation